### PR TITLE
Change composer type to vendor module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "lekoala/silverstripe-softdelete",
     "description": "Soft delete extension for SilverStripe",
-    "type": "silverstripe-module",
+    "type": "silverstripe-vendormodule",
     "keywords": [
         "silverstripe",
         "module",


### PR DESCRIPTION
Composer packages with the type "silverstripe-module" are installed in the root module. To keep the root directories of projects clear of dependencies (which was the trend with SS4), this should be changed to "silverstripe-vendormodule".