### PR TITLE
Fix: Replace removed Controller::has_curr() for SS6 compatibility

### DIFF
--- a/code/SoftDeletable.php
+++ b/code/SoftDeletable.php
@@ -168,11 +168,9 @@ class SoftDeletable extends Extension
         }
 
         // Hide on ProfileController
-        if (Controller::has_curr()) {
-            $className = get_class(Controller::curr());
-            if (strpos($className, 'CMSProfileController') !== false) {
-                return;
-            }
+        $curr = Controller::curr();
+        if ($curr && strpos(get_class($curr), 'CMSProfileController') !== false) {
+            return;
         }
 
         // Use canDelete

--- a/code/SoftDeletable.php
+++ b/code/SoftDeletable.php
@@ -99,7 +99,7 @@ class SoftDeletable extends Extension
      * Update any requests to hide deleted records
      * @return void
      */
-    public function augmentSQL(SQLSelect $query, DataQuery $dataQuery = null)
+    public function augmentSQL(SQLSelect $query, ?DataQuery $dataQuery = null)
     {
         // Filters are disabled globally
         if (self::$disable) {


### PR DESCRIPTION
## Summary

`Controller::has_curr()` was removed in SilverStripe 6. This causes an `Uncaught Error: Call to undefined method` on line 171 of `SoftDeletable.php`.

## Fix

Replaced with `Controller::curr()` which now returns `null` (instead of throwing an exception) when there is no current controller. This is the documented upgrade path per the [CMS 6.0.0 changelog](https://docs.silverstripe.org/en/6/changelogs/6.0.0/#controller-has-curr).

## Testing

Verified no other instances of `has_curr()` exist in the codebase.